### PR TITLE
Check on startup if MPXV sensor is connected

### DIFF
--- a/FLipWare/FLipWare.ino
+++ b/FLipWare/FLipWare.ino
@@ -83,7 +83,8 @@ struct SensorData sensorData {
   .calib_now=1,    // calibrate zeropoint right at startup !
   .cx=0, .cy=0,
   .xDriftComp=0, .yDriftComp=0,
-  .xLocalMax=0, .yLocalMax=0
+  .xLocalMax=0, .yLocalMax=0,
+  .ignorePressure = 0
 };
 
 
@@ -121,6 +122,12 @@ void setup() {
   initButtons();
   initDebouncers();
   init_CIM_frame();  // for AsTeRICS CIM protocol compatibility
+  
+  pinMode(PRESSURE_SENSOR_PIN,INPUT_PULLUP);
+  if(analogRead(PRESSURE_SENSOR_PIN) > 900)
+  {
+	  sensorData.ignorePressure = 1;
+  }
 
   bootstrapSlotAddresses();   // initialize EEPROM if necessary
   readFromEEPROMSlotNumber(0, true); // read slot from first EEPROM slot if available !
@@ -167,7 +174,8 @@ void loop() {
   }
 
   // get current sensor values
-  sensorData.pressure = analogRead(PRESSURE_SENSOR_PIN);
+  if(!sensorData.ignorePressure) sensorData.pressure = analogRead(PRESSURE_SENSOR_PIN);
+  else sensorData.pressure = 512;
   padState=updateCirquePad(&padX,&padY); 
 
   // perform periodic updates  

--- a/FLipWare/FlipWare.h
+++ b/FLipWare/FlipWare.h
@@ -117,7 +117,8 @@ struct SensorData {
   uint8_t calib_now;
   int16_t  cx, cy;
   int xDriftComp, yDriftComp;
-  int xLocalMax, yLocalMax;  
+  int xLocalMax, yLocalMax;
+  uint8_t ignorePressure;
 };
 
 /**


### PR DESCRIPTION
If the analog sensor is not connected, we are reading a floating analog pin -> spurious clicks (sip/puff actions).

This PR checks on startup if the analog sensor connected:
* set pin to input+pullup
* if value is higher than 900, we assume an unconnected pin
* further analog reading is not done, instead the value is fixed to 512